### PR TITLE
Change how filtering and ordering aliases work

### DIFF
--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -308,14 +308,14 @@ If you want to make a `Filter` required, you can do so by setting the `required`
 -8<- "filtering/filter_required.py"
 ```
 
-### Required aliases
+### Aliases
 
-The `required_aliases` argument can be used to specify additional expressions that
-should be added as aliases to the queryset when the `Filter` is used. This is useful
-as a way to make the actual `Filter` more readable when complex expressions are needed.
+Sometimes a `Filter` may require additional expressions to be added as aliases
+to the queryset when the `Filter` is used. For this, you can define a function
+that returns a dictionary of expressions and decorate it with the `aliases` decorator.
 
 ```python
--8<- "filtering/filter_required_aliases.py"
+-8<- "filtering/filter_aliases.py"
 ```
 
 ### Field name

--- a/docs/ordering.md
+++ b/docs/ordering.md
@@ -179,6 +179,16 @@ the `null_placement` argument can be used to specify the position of null values
 
 By default, null values are placed according to your database default.
 
+### Aliases
+
+Sometimes a `Order` may require additional expressions to be added as aliases
+to the queryset when the `Order` is used. For this, you can define a function
+that returns a dictionary of expressions and decorate it with the `aliases` decorator.
+
+```python
+-8<- "ordering/order_aliases.py"
+```
+
 ### Field name
 
 A `field_name` can be provided to explicitly set the Django model field name

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -536,6 +536,15 @@ The name of given to the persisted documents registration view in the URLconf.
 
 ///
 
+/// details | `PG_TEXT_SEARCH_PREFIX`
+    attrs: {id: pg_text_search_prefix}
+
+Type: `str` | Default: `"_undine_ts_vector"`
+
+A prefix to use for the filter aliases of postgres full text search Filters.
+
+///
+
 /// details | `PREFETCH_HACK_CACHE_KEY`
     attrs: {id: prefetch_hack_cache_key}
 

--- a/docs/snippets/filtering/filter_aliases.py
+++ b/docs/snippets/filtering/filter_aliases.py
@@ -1,16 +1,17 @@
 from django.db.models import F, OuterRef, Q
 
-from undine import Filter, FilterSet
+from undine import DjangoExpression, Filter, FilterSet, GQLInfo
 from undine.utils.model_utils import SubqueryCount
 
 from .models import Task
 
 
 class TaskFilterSet(FilterSet[Task]):
-    has_more_copies = Filter(
-        Q(copies__gt=F("non_copies")),
-        required_aliases={
+    has_more_copies = Filter(Q(copies__gt=F("non_copies")))
+
+    @has_more_copies.aliases
+    def has_more_copies_aliases(self, info: GQLInfo, *, value: bool) -> dict[str, DjangoExpression]:
+        return {
             "copies": SubqueryCount(Task.objects.filter(name=OuterRef("name"))),
             "non_copies": SubqueryCount(Task.objects.exclude(name=OuterRef("name"))),
-        },
-    )
+        }

--- a/docs/snippets/ordering/order_aliases.py
+++ b/docs/snippets/ordering/order_aliases.py
@@ -1,0 +1,13 @@
+from django.db.models.functions import Lower
+
+from undine import DjangoExpression, GQLInfo, Order, OrderSet
+
+from .models import Task
+
+
+class TaskOrderSet(OrderSet[Task]):
+    name = Order("name_lower")
+
+    @name.aliases
+    def name_lower(self, info: GQLInfo, *, descending: bool) -> dict[str, DjangoExpression]:
+        return {"name_lower": Lower("name")}

--- a/example_project/app/models.py
+++ b/example_project/app/models.py
@@ -32,7 +32,7 @@ from django.db.models import (
 )
 
 if TYPE_CHECKING:
-    from undine.typing import ModelManager, RelatedManager
+    from example_project.project.typing import ModelManager, RelatedManager
 
 __all__ = [
     "AcceptanceCriteria",

--- a/example_project/example/models.py
+++ b/example_project/example/models.py
@@ -16,7 +16,7 @@ from django.db.models import (
 )
 
 if TYPE_CHECKING:
-    from undine.typing import RelatedManager
+    from example_project.project.typing import RelatedManager
 
 __all__ = [
     "Example",

--- a/example_project/project/typing.py
+++ b/example_project/project/typing.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+from undine.typing import TModel
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable, Iterator, Mapping
+
+    from django.db.models import QuerySet
+
+
+class ModelManager(Protocol[TModel]):  # noqa: PLR0904
+    """Protocol of a model manager."""
+
+    def get_queryset(self) -> QuerySet[TModel]: ...
+
+    def iterator(self, chunk_size: int | None = None) -> Iterator[TModel]: ...
+
+    def aggregate(self, *args: Any, **kwargs: Any) -> dict[str, Any]: ...
+
+    def count(self) -> int: ...
+
+    def get(self, *args: Any, **kwargs: Any) -> TModel: ...
+
+    def create(self, **kwargs: Any) -> TModel: ...
+
+    def bulk_create(  # noqa: PLR0917
+        self,
+        objs: Iterable[TModel],
+        batch_size: int | None = None,
+        ignore_conflicts: bool = False,  # noqa: FBT001, FBT002
+        update_conflicts: bool = False,  # noqa: FBT001, FBT002
+        update_fields: Collection[str] | None = None,
+        unique_fields: Collection[str] | None = None,
+    ) -> list[TModel]: ...
+
+    def bulk_update(
+        self,
+        objs: Iterable[TModel],
+        fields: Collection[str],
+        batch_size: int | None = None,
+    ) -> int: ...
+
+    def get_or_create(
+        self,
+        defaults: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> tuple[TModel, bool]: ...
+
+    def update_or_create(
+        self,
+        defaults: Mapping[str, Any] | None = None,
+        create_defaults: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> tuple[TModel, bool]: ...
+
+    def first(self) -> TModel | None: ...
+
+    def last(self) -> TModel | None: ...
+
+    def delete(self) -> int: ...
+
+    def update(self, **kwargs: Any) -> int: ...
+
+    def exists(self) -> bool: ...
+
+    def contains(self, obj: TModel) -> bool: ...
+
+    def values(self, *fields: str, **expressions: Any) -> QuerySet[TModel]: ...
+
+    def values_list(self, *fields: str, flat: bool = False, named: bool = False) -> QuerySet[TModel]: ...
+
+    def none(self) -> QuerySet[TModel]: ...
+
+    def all(self) -> QuerySet[TModel]: ...
+
+    def filter(self, *args: Any, **kwargs: Any) -> QuerySet[TModel]: ...
+
+    def exclude(self, *args: Any, **kwargs: Any) -> QuerySet[TModel]: ...
+
+    def union(self, *other_qs: QuerySet[TModel], all: bool = False) -> QuerySet[TModel]: ...  # noqa: A002
+
+    def intersection(self, *other_qs: QuerySet[TModel]) -> QuerySet[TModel]: ...
+
+    def difference(self, *other_qs: QuerySet[TModel]) -> QuerySet[TModel]: ...
+
+    def select_related(self, *fields: Any) -> QuerySet[TModel]: ...
+
+    def prefetch_related(self, *lookups: Any) -> QuerySet[TModel]: ...
+
+    def annotate(self, *args: Any, **kwargs: Any) -> QuerySet[TModel]: ...
+
+    def alias(self, *args: Any, **kwargs: Any) -> QuerySet[TModel]: ...
+
+    def order_by(self, *field_names: Any) -> QuerySet[TModel]: ...
+
+    def distinct(self, *field_names: Any) -> QuerySet[TModel]: ...
+
+    def reverse(self) -> QuerySet[TModel]: ...
+
+    def defer(self, *fields: Any) -> QuerySet[TModel]: ...
+
+    def only(self, *fields: Any) -> QuerySet[TModel]: ...
+
+    def using(self, alias: str | None) -> QuerySet[TModel]: ...
+
+
+class RelatedManager(ModelManager, Protocol[TModel]):
+    """Protocol of a manager for one-to-many and many-to-many relations."""
+
+    def add(self, *objs: TModel, bulk: bool = True) -> int: ...
+
+    def set(
+        self,
+        objs: Iterable[TModel],
+        *,
+        clear: bool = False,
+        through_defaults: Any = None,
+    ) -> QuerySet[TModel]: ...
+
+    def clear(self) -> None: ...
+
+    def remove(self, obj: Iterable[TModel], bulk: bool = True) -> TModel: ...  # noqa: FBT001, FBT002
+
+    def create(self, through_defaults: Any = None, **kwargs: Any) -> TModel: ...

--- a/tests/test_converters/test_convert_to_graphql_type.py
+++ b/tests/test_converters/test_convert_to_graphql_type.py
@@ -253,6 +253,7 @@ class MyTypedDict(TypedDict):
 
     foo: int
     bar: str
+    fizz_buzz: datetime.datetime
 
 
 def test_convert_to_graphql_type__typed_dict__output() -> None:
@@ -263,6 +264,7 @@ def test_convert_to_graphql_type__typed_dict__output() -> None:
     assert result.fields == {
         "foo": GraphQLField(GraphQLNonNull(GraphQLInt)),
         "bar": GraphQLField(GraphQLNonNull(GraphQLString)),
+        "fizzBuzz": GraphQLField(GraphQLNonNull(GraphQLDateTime)),
     }
     assert result.description == "Description."
 
@@ -273,8 +275,9 @@ def test_convert_to_graphql_type__typed_dict__input() -> None:
     assert isinstance(result, GraphQLInputObjectType)
     assert result.name == "MyTypedDict"
     assert result.fields == {
-        "foo": GraphQLInputField(GraphQLNonNull(GraphQLInt)),
-        "bar": GraphQLInputField(GraphQLNonNull(GraphQLString)),
+        "foo": GraphQLInputField(GraphQLNonNull(GraphQLInt), out_name="foo"),
+        "bar": GraphQLInputField(GraphQLNonNull(GraphQLString), out_name="bar"),
+        "fizzBuzz": GraphQLInputField(GraphQLNonNull(GraphQLDateTime), out_name="fizz_buzz"),
     }
     assert result.description == "Description."
 

--- a/tests/test_filtering/test_filterset.py
+++ b/tests/test_filtering/test_filterset.py
@@ -418,16 +418,3 @@ def test_filterset__many__all() -> None:
     assert results.filters == [Q(name__exact="foo") & Q(name__exact="bar")]
     assert results.distinct is False
     assert results.aliases == {}
-
-
-def test_filterset__required_aliases() -> None:
-    class MyFilterSet(FilterSet[Task], auto=False):
-        name = Filter(required_aliases={"foo": Count("*")})
-
-    data = {"name": "foo"}
-
-    results = MyFilterSet.__build__(filter_data=data, info=mock_gql_info())
-
-    assert results.filters == [Q(name__exact="foo")]
-    assert results.distinct is False
-    assert results.aliases == {"foo": Count("*")}

--- a/undine/converters/impl/convert_to_description.py
+++ b/undine/converters/impl/convert_to_description.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import Any
 
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -73,3 +74,11 @@ def _(ref: GenericForeignKey, **kwargs: Any) -> Any:  # Required for Django<5.1
 @convert_to_description.register
 def _(ref: Connection, **kwargs: Any) -> Any:
     return ref.description
+
+
+with suppress(ImportError):
+    from undine.utils.full_text_search import PostgresFTS
+
+    @convert_to_description.register
+    def _(_: PostgresFTS, **kwargs: Any) -> Any:
+        return None

--- a/undine/converters/impl/convert_to_field_ref.py
+++ b/undine/converters/impl/convert_to_field_ref.py
@@ -58,7 +58,12 @@ def _(ref: CombinableExpression, **kwargs: Any) -> Any:
     caller: UndineField = kwargs["caller"]
     determine_output_field(ref, model=caller.query_type.__model__)
 
+    user_func = caller.optimizer_func
+
     def optimizer_func(field: UndineField, data: OptimizationData, info: GQLInfo) -> None:
+        if user_func is not None:
+            user_func(field, data, info)
+
         data.annotations[field.name] = ref
 
     caller.optimizer_func = optimizer_func
@@ -69,7 +74,12 @@ def _(ref: CombinableExpression, **kwargs: Any) -> Any:
 def _(ref: Q, **kwargs: Any) -> Any:
     caller: UndineField = kwargs["caller"]
 
+    user_func = caller.optimizer_func
+
     def optimizer_func(field: UndineField, data: OptimizationData, info: GQLInfo) -> None:
+        if user_func is not None:
+            user_func(field, data, info)
+
         data.annotations[field.name] = ref
 
     caller.optimizer_func = optimizer_func
@@ -215,7 +225,12 @@ def _(ref: Connection, **kwargs: Any) -> Any:
 def _(ref: type[Calculation], **kwargs: Any) -> Any:
     caller: UndineField = kwargs["caller"]
 
+    user_func = caller.optimizer_func
+
     def optimizer_func(field: UndineField, data: OptimizationData, info: GQLInfo) -> None:
+        if user_func is not None:
+            user_func(field, data, info)
+
         arg_values = get_arguments(info)
         field_name = get_queried_field_name(field.name, info)
         calculation = ref(field_name, **arg_values)

--- a/undine/converters/impl/convert_to_filter_resolver.py
+++ b/undine/converters/impl/convert_to_filter_resolver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from types import FunctionType
 from typing import Any
 
@@ -43,3 +44,11 @@ def _(_: GenericForeignKey, **kwargs: Any) -> GraphQLFilterResolver:
     caller: Filter = kwargs["caller"]
     lookup = f"{caller.field_name}{LOOKUP_SEP}{caller.lookup}"
     return FilterModelFieldResolver(lookup=lookup)
+
+
+with suppress(ImportError):
+    from undine.utils.full_text_search import PostgresFTS, PostgresFTSExpressionResolver
+
+    @convert_to_filter_resolver.register
+    def _(ref: PostgresFTS, **kwargs: Any) -> GraphQLFilterResolver:
+        return PostgresFTSExpressionResolver(fts=ref)

--- a/undine/converters/impl/convert_to_input_ref.py
+++ b/undine/converters/impl/convert_to_input_ref.py
@@ -28,14 +28,14 @@ from undine.utils.model_utils import get_model_field, get_reverse_field_name
 @convert_to_input_ref.register
 def _(_: None, **kwargs: Any) -> Any:
     caller: Input = kwargs["caller"]
-    field = get_model_field(model=caller.mutation_type.__model__, lookup=caller.name)
+    field = get_model_field(model=caller.mutation_type.__model__, lookup=caller.field_name)
     return convert_to_input_ref(field, **kwargs)
 
 
 @convert_to_input_ref.register
-def _(_: F, **kwargs: Any) -> Any:
+def _(ref: F, **kwargs: Any) -> Any:
     caller: Input = kwargs["caller"]
-    field = get_model_field(model=caller.mutation_type.__model__, lookup=caller.name)
+    field = get_model_field(model=caller.mutation_type.__model__, lookup=ref.name)
     return convert_to_input_ref(field, **kwargs)
 
 
@@ -165,7 +165,7 @@ def _(ref: type[MutationType], **kwargs: Any) -> Any:
 
     # Remove the Input for the reverse relation from the MutationType used as the Input for this one.
     model = caller.mutation_type.__model__
-    field = get_model_field(model=model, lookup=caller.name)
+    field = get_model_field(model=model, lookup=caller.field_name)
     reverse_field_name = get_reverse_field_name(field=field)
     ref.__input_map__.pop(reverse_field_name, None)
 

--- a/undine/converters/impl/is_input_required.py
+++ b/undine/converters/impl/is_input_required.py
@@ -67,7 +67,7 @@ def _(ref: FunctionType, **kwargs: Any) -> bool:
 @is_input_required.register
 def _(_: type[MutationType], **kwargs: Any) -> bool:
     caller: Input = kwargs["caller"]
-    field = get_model_field(model=caller.mutation_type.__model__, lookup=caller.name)
+    field = get_model_field(model=caller.mutation_type.__model__, lookup=caller.field_name)
     return is_input_required(field, caller=caller)
 
 

--- a/undine/dataclasses.py
+++ b/undine/dataclasses.py
@@ -72,6 +72,7 @@ class OrderResults:
     """Holds the results of a QueryType ordering operation."""
 
     order_by: list[OrderBy]
+    aliases: dict[str, DjangoExpression]
     order_count: int = 0
 
 

--- a/undine/entrypoint.py
+++ b/undine/entrypoint.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from graphql import GraphQLArgumentMap, GraphQLFieldResolver, GraphQLObjectType, GraphQLOutputType
 
     from undine.directives import Directive
-    from undine.typing import EntrypointParams, PermissionFunc, RootTypeParams
+    from undine.typing import EntrypointParams, FieldPermFunc, RootTypeParams
 
 __all__ = [
     "Entrypoint",
@@ -162,7 +162,7 @@ class Entrypoint:
         self.extensions[undine_settings.ENTRYPOINT_EXTENSIONS_KEY] = self
 
         self.resolver_func: GraphQLFieldResolver | None = None
-        self.permissions_func: PermissionFunc | None = None
+        self.permissions_func: FieldPermFunc | None = None
 
     def __connect__(self, root_type: type[RootType], name: str) -> None:
         """Connect this `Entrypoint` to the given `RootType` using the given name."""
@@ -229,7 +229,7 @@ class Entrypoint:
         self.resolver_func = cache_signature_if_function(func, depth=1)
         return func
 
-    def permissions(self, func: PermissionFunc | None = None, /) -> PermissionFunc:
+    def permissions(self, func: FieldPermFunc | None = None, /) -> FieldPermFunc:
         """Decorate a function to add it as a permission check for this Entrypoint."""
         if func is None:  # Allow `@<entrypoint_name>.permissions()`
             return self.permissions  # type: ignore[return-value]

--- a/undine/mutation.py
+++ b/undine/mutation.py
@@ -44,15 +44,7 @@ if TYPE_CHECKING:
 
     from undine import QueryType
     from undine.directives import Directive
-    from undine.typing import (
-        DefaultValueType,
-        GQLInfo,
-        InputParams,
-        InputPermFunc,
-        MutationTypeParams,
-        PermissionFunc,
-        ValidatorFunc,
-    )
+    from undine.typing import DefaultValueType, GQLInfo, InputParams, InputPermFunc, MutationTypeParams, ValidatorFunc
 
 __all__ = [
     "Input",
@@ -316,7 +308,7 @@ class Input:
         self.extensions[undine_settings.INPUT_EXTENSIONS_KEY] = self
 
         self.validator_func: ValidatorFunc | None = None
-        self.permissions_func: PermissionFunc | None = None
+        self.permissions_func: InputPermFunc | None = None
 
     def __connect__(self, mutation_type: type[MutationType], name: str) -> None:
         """Connect this `Input` to the given `MutationType` using the given name."""

--- a/undine/optimizer/optimizer.py
+++ b/undine/optimizer/optimizer.py
@@ -191,6 +191,7 @@ class QueryOptimizer(GraphQLASTWalker):
                 )
 
             self.optimization_data.order_by.extend(order_results.order_by)
+            self.optimization_data.aliases |= order_results.aliases
 
         query_type.__optimizations__(self.optimization_data, self.info)
 

--- a/undine/query.py
+++ b/undine/query.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from undine import FilterSet, GQLInfo, InterfaceType, OrderSet
     from undine.directives import Directive
     from undine.optimizer.optimizer import OptimizationData
-    from undine.typing import FieldParams, OptimizerFunc, PermissionFunc, QueryTypeParams
+    from undine.typing import FieldParams, FieldPermFunc, OptimizerFunc, QueryTypeParams
 
 __all__ = [
     "Field",
@@ -283,7 +283,7 @@ class Field:
 
         self.resolver_func: GraphQLFieldResolver | None = None
         self.optimizer_func: OptimizerFunc | None = None
-        self.permissions_func: PermissionFunc | None = None
+        self.permissions_func: FieldPermFunc | None = None
 
     def __connect__(self, query_type: type[QueryType], name: str) -> None:
         """Connect this `Field` to the given `QueryType` using the given name."""
@@ -356,7 +356,7 @@ class Field:
         self.optimizer_func = get_wrapped_func(func)
         return func
 
-    def permissions(self, func: PermissionFunc | None = None, /) -> PermissionFunc:
+    def permissions(self, func: FieldPermFunc | None = None, /) -> FieldPermFunc:
         """Decorate a function to add it as a permission check for this field."""
         if func is None:  # Allow `@<field_name>.permissions()`
             return self.permissions  # type: ignore[return-value]

--- a/undine/resolvers/query.py
+++ b/undine/resolvers/query.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from undine import Entrypoint, Field, InterfaceType, UnionType
     from undine.optimizer.optimizer import QueryOptimizer
     from undine.relay import Connection, PaginationHandler
-    from undine.typing import GQLInfo, RelatedManager
+    from undine.typing import GQLInfo
 
 __all__ = [
     "ConnectionResolver",
@@ -210,7 +210,7 @@ class ModelManyRelatedFieldResolver(Generic[TModel]):
 
     def __call__(self, root: Model, info: GQLInfo, **kwargs: Any) -> list[TModel]:
         field_name = get_queried_field_name(self.field.name, info)
-        manager: RelatedManager[TModel] = getattr(root, field_name)
+        manager: Manager[TModel] = getattr(root, field_name)
         instances = list(manager.get_queryset())
 
         if self.field.permissions_func is not None:

--- a/undine/settings.py
+++ b/undine/settings.py
@@ -234,6 +234,9 @@ class UndineDefaultSettings(NamedTuple):
     SDL_PRINTER: type[SDLPrinter] = "undine.utils.graphql.sdl_printer.SDLPrinter"  # type: ignore[assignment]
     """The SDL printer to use."""
 
+    PG_TEXT_SEARCH_PREFIX: str = "_undine_ts_vector"
+    """A prefix to use for the filter aliases of postgres full text search Filters."""
+
     # Extensions keys
 
     CALCULATION_ARGUMENT_EXTENSIONS_KEY: str = "undine_calculation_argument"

--- a/undine/typing.py
+++ b/undine/typing.py
@@ -9,6 +9,7 @@ from functools import cache
 from types import FunctionType, GenericAlias, UnionType
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Generic,
     Literal,
@@ -70,7 +71,6 @@ from graphql import (
 from graphql.pyutils import AwaitableOrValue
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Iterator, Mapping
     from http.cookies import SimpleCookie
 
     from asgiref.typing import ASGISendEvent
@@ -122,6 +122,8 @@ __all__ = [
     "ErrorMessage",
     "ExecutionResultGen",
     "FieldParams",
+    "FieldPermFunc",
+    "FilterAliasesFunc",
     "FilterParams",
     "FilterSetParams",
     "GQLInfo",
@@ -135,24 +137,22 @@ __all__ = [
     "LiteralArg",
     "ManyMatch",
     "ModelField",
-    "ModelManager",
     "MutationKind",
     "MutationTypeParams",
     "NextMessage",
     "NodeDict",
     "ObjectSelections",
     "OptimizerFunc",
+    "OrderAliasesFunc",
     "OrderParams",
     "OrderSetParams",
     "PageInfoDict",
     "ParametrizedType",
-    "PermissionFunc",
     "PingMessage",
     "PongMessage",
     "ProtocolType",
     "QueryTypeParams",
     "RelatedField",
-    "RelatedManager",
     "RequestMethod",
     "RootTypeParams",
     "Selections",
@@ -251,7 +251,7 @@ class DispatchProtocol(Protocol[T_co]):
     def __call__(self, key: Any, **kwargs: Any) -> T_co: ...
 
 
-class DjangoRequestProtocol(Protocol[TUser]):
+class DjangoRequestProtocol(Protocol[TUser]):  # noqa: PLR0904
     """Protocol of a Django 'HttpRequest' object. Abbreviated to the most useful properties."""
 
     @property
@@ -329,6 +329,27 @@ class DjangoRequestProtocol(Protocol[TUser]):
     def response_content_type(self, value: str) -> None:
         """Set by decorators in 'undine.http.utils'."""
 
+    def is_secure(self) -> bool:
+        """A boolean representing whether the request is over HTTPS."""
+
+    def accepts(self, media_type: str) -> bool:
+        """Does the client accept a response in the given media type?"""
+
+    def get_host(self) -> str:
+        """Return the HTTP host using the environment or request headers."""
+
+    def get_port(self) -> str:
+        """Return the port number for the request as a string."""
+
+    def get_full_path(self, force_append_slash: bool = False) -> str:  # noqa: FBT001,FBT002
+        """Return the full path for the request."""
+
+    def get_full_path_info(self, force_append_slash: bool = False) -> str:  # noqa: FBT001,FBT002
+        """Return the full path info for the request."""
+
+    def build_absolute_uri(self, location: str | None = None) -> str:
+        """Build an absolute URI from the location and the variables available in this request."""
+
 
 class DjangoResponseProtocol(Protocol):
     """Protocol of a Django 'HttpResponse' object. Abbreviated to the most useful properties."""
@@ -383,122 +404,6 @@ class DjangoTestClientResponseProtocol(DjangoResponseProtocol, Protocol):
 
     def json(self) -> dict[str, Any]:
         """The JSON content of the response."""
-
-
-class ModelManager(Protocol[TModel]):  # noqa: PLR0904
-    """Protocol of a model manager."""
-
-    def get_queryset(self) -> QuerySet[TModel]: ...
-
-    def iterator(self, chunk_size: int | None = None) -> Iterator[TModel]: ...
-
-    def aggregate(self, *args: Any, **kwargs: Any) -> dict[str, Any]: ...
-
-    def count(self) -> int: ...
-
-    def get(self, *args: Any, **kwargs: Any) -> TModel: ...
-
-    def create(self, **kwargs: Any) -> TModel: ...
-
-    def bulk_create(  # noqa: PLR0917
-        self,
-        objs: Iterable[TModel],
-        batch_size: int | None = None,
-        ignore_conflicts: bool = False,  # noqa: FBT001, FBT002
-        update_conflicts: bool = False,  # noqa: FBT001, FBT002
-        update_fields: Collection[str] | None = None,
-        unique_fields: Collection[str] | None = None,
-    ) -> list[TModel]: ...
-
-    def bulk_update(
-        self,
-        objs: Iterable[TModel],
-        fields: Collection[str],
-        batch_size: int | None = None,
-    ) -> int: ...
-
-    def get_or_create(
-        self,
-        defaults: Mapping[str, Any] | None = None,
-        **kwargs: Any,
-    ) -> tuple[TModel, bool]: ...
-
-    def update_or_create(
-        self,
-        defaults: Mapping[str, Any] | None = None,
-        create_defaults: Mapping[str, Any] | None = None,
-        **kwargs: Any,
-    ) -> tuple[TModel, bool]: ...
-
-    def first(self) -> TModel | None: ...
-
-    def last(self) -> TModel | None: ...
-
-    def delete(self) -> int: ...
-
-    def update(self, **kwargs: Any) -> int: ...
-
-    def exists(self) -> bool: ...
-
-    def contains(self, obj: TModel) -> bool: ...
-
-    def values(self, *fields: str, **expressions: Any) -> QuerySet[TModel]: ...
-
-    def values_list(self, *fields: str, flat: bool = False, named: bool = False) -> QuerySet[TModel]: ...
-
-    def none(self) -> QuerySet[TModel]: ...
-
-    def all(self) -> QuerySet[TModel]: ...
-
-    def filter(self, *args: Any, **kwargs: Any) -> QuerySet[TModel]: ...
-
-    def exclude(self, *args: Any, **kwargs: Any) -> QuerySet[TModel]: ...
-
-    def union(self, *other_qs: QuerySet[TModel], all: bool = False) -> QuerySet[TModel]: ...  # noqa: A002
-
-    def intersection(self, *other_qs: QuerySet[TModel]) -> QuerySet[TModel]: ...
-
-    def difference(self, *other_qs: QuerySet[TModel]) -> QuerySet[TModel]: ...
-
-    def select_related(self, *fields: Any) -> QuerySet[TModel]: ...
-
-    def prefetch_related(self, *lookups: Any) -> QuerySet[TModel]: ...
-
-    def annotate(self, *args: Any, **kwargs: Any) -> QuerySet[TModel]: ...
-
-    def alias(self, *args: Any, **kwargs: Any) -> QuerySet[TModel]: ...
-
-    def order_by(self, *field_names: Any) -> QuerySet[TModel]: ...
-
-    def distinct(self, *field_names: Any) -> QuerySet[TModel]: ...
-
-    def reverse(self) -> QuerySet[TModel]: ...
-
-    def defer(self, *fields: Any) -> QuerySet[TModel]: ...
-
-    def only(self, *fields: Any) -> QuerySet[TModel]: ...
-
-    def using(self, alias: str | None) -> QuerySet[TModel]: ...
-
-
-class RelatedManager(ModelManager, Protocol[TModel]):
-    """Protocol of a manager for one-to-many and many-to-many relations."""
-
-    def add(self, *objs: TModel, bulk: bool = True) -> int: ...
-
-    def set(
-        self,
-        objs: Iterable[TModel],
-        *,
-        clear: bool = False,
-        through_defaults: Any = None,
-    ) -> QuerySet[TModel]: ...
-
-    def clear(self) -> None: ...
-
-    def remove(self, obj: Iterable[TModel], bulk: bool = True) -> TModel: ...  # noqa: FBT001, FBT002
-
-    def create(self, through_defaults: Any = None, **kwargs: Any) -> TModel: ...
 
 
 # Enums
@@ -891,7 +796,6 @@ class FilterParams(TypedDict, total=False):
     distinct: bool
     required: bool
     description: str | None
-    required_aliases: dict[str, DjangoExpression]
     deprecation_reason: str | None
     schema_name: str
     directives: list[Directive]
@@ -952,15 +856,131 @@ class CalculationArgumentParams(TypedDict, total=False):
     extensions: dict[str, Any]
 
 
+class PostgresFTSLangSpecificFields(TypedDict, total=False):
+    """Specify fields for text search per language."""
+
+    # Cannot use "Iterable[str]" since "str" is also an iterable of strings.
+    arabic: list[str] | tuple[str, ...] | set[str]
+    armenian: list[str] | tuple[str, ...] | set[str]
+    basque: list[str] | tuple[str, ...] | set[str]
+    catalan: list[str] | tuple[str, ...] | set[str]
+    danish: list[str] | tuple[str, ...] | set[str]
+    dutch: list[str] | tuple[str, ...] | set[str]
+    english: list[str] | tuple[str, ...] | set[str]
+    finnish: list[str] | tuple[str, ...] | set[str]
+    french: list[str] | tuple[str, ...] | set[str]
+    german: list[str] | tuple[str, ...] | set[str]
+    greek: list[str] | tuple[str, ...] | set[str]
+    hindi: list[str] | tuple[str, ...] | set[str]
+    hungarian: list[str] | tuple[str, ...] | set[str]
+    indonesian: list[str] | tuple[str, ...] | set[str]
+    irish: list[str] | tuple[str, ...] | set[str]
+    italian: list[str] | tuple[str, ...] | set[str]
+    lithuanian: list[str] | tuple[str, ...] | set[str]
+    nepali: list[str] | tuple[str, ...] | set[str]
+    norwegian: list[str] | tuple[str, ...] | set[str]
+    portuguese: list[str] | tuple[str, ...] | set[str]
+    romanian: list[str] | tuple[str, ...] | set[str]
+    russian: list[str] | tuple[str, ...] | set[str]
+    serbian: list[str] | tuple[str, ...] | set[str]
+    spanish: list[str] | tuple[str, ...] | set[str]
+    swedish: list[str] | tuple[str, ...] | set[str]
+    tamil: list[str] | tuple[str, ...] | set[str]
+    turkish: list[str] | tuple[str, ...] | set[str]
+    yiddish: list[str] | tuple[str, ...] | set[str]
+
+
+FTSLang: TypeAlias = Literal[
+    "arabic",
+    "armenian",
+    "basque",
+    "catalan",
+    "danish",
+    "dutch",
+    "english",
+    "finnish",
+    "french",
+    "german",
+    "greek",
+    "hindi",
+    "hungarian",
+    "indonesian",
+    "irish",
+    "italian",
+    "lithuanian",
+    "nepali",
+    "norwegian",
+    "portuguese",
+    "romanian",
+    "russian",
+    "serbian",
+    "spanish",
+    "swedish",
+    "tamil",
+    "turkish",
+    "yiddish",
+]
+
+LangCode: TypeAlias = Literal[
+    "ar",
+    "hy",
+    "eu",
+    "ca",
+    "da",
+    "nl",
+    "en",
+    "fi",
+    "fr",
+    "de",
+    "el",
+    "hi",
+    "hu",
+    "id",
+    "ga",
+    "it",
+    "lt",
+    "ne",
+    "nb",
+    "pt",
+    "ro",
+    "ru",
+    "sr",
+    "es",
+    "sv",
+    "ta",
+    "tr",
+    "yi",
+]
+
+LangSep: TypeAlias = Literal["|", "&", "<->", "<1>", "<2>", "<3>", "<4>", "<5>", "<6>", "<7>", "<8>", "<9>"]
+
+
 # Resolvers
 
-PermissionFunc: TypeAlias = Callable[[Any, GQLInfo, Any], None]
-InputPermFunc: TypeAlias = Callable[[Any, GQLInfo, Any], None]
-ValidatorFunc: TypeAlias = Callable[[Any, GQLInfo, Any], None]
-OptimizerFunc: TypeAlias = Callable[[Any, "OptimizationData", GQLInfo], None]
+_AnyValue: TypeAlias = Annotated[Any, "value"]
+_AnyModel: TypeAlias = Annotated[Any, "django.db.models.Model"]
+_AnyField: TypeAlias = Annotated[Any, "undine.Field"]
+_AnyFilter: TypeAlias = Annotated[Any, "undine.Filter"]
+_AnyOrder: TypeAlias = Annotated[Any, "undine.Order"]
 
-GraphQLFilterResolver: TypeAlias = Callable[..., Q]
-"""(self: Filter, info: GQLInfo, *, value: Any) -> Q"""
+FieldPermFunc: TypeAlias = Callable[[_AnyModel, GQLInfo, _AnyValue], None]
+InputPermFunc: TypeAlias = Callable[[_AnyModel, GQLInfo, _AnyValue], None]
+ValidatorFunc: TypeAlias = Callable[[_AnyModel, GQLInfo, _AnyValue], None]
+
+OptimizerFunc: TypeAlias = Callable[[_AnyField, "OptimizationData", GQLInfo], None]
+
+
+class FilterAliasesFunc(Protocol):
+    def __call__(self, root: _AnyFilter, /, info: GQLInfo, *, value: Any) -> dict[str, DjangoExpression]: ...
+
+
+class OrderAliasesFunc(Protocol):
+    def __call__(self, root: _AnyOrder, /, info: GQLInfo, *, descending: bool) -> dict[str, DjangoExpression]: ...
+
+
+class GraphQLFilterResolver(Protocol):
+    def __call__(self, root: _AnyFilter, /, info: GQLInfo, *, value: Any) -> Q: ...
+
 
 # Callbacks
 

--- a/undine/utils/full_text_search.py
+++ b/undine/utils/full_text_search.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import dataclasses
+import re
+import unicodedata
+import urllib.parse
+from collections import UserString
+from typing import TYPE_CHECKING, Unpack
+
+from django.contrib.postgres.search import SearchQuery, SearchVector
+from django.db.models import Q
+from django.utils.translation import get_language_from_path, get_language_from_request
+
+from undine.settings import undine_settings
+
+from .reflection import get_members
+
+if TYPE_CHECKING:
+    from undine import Filter
+    from undine.typing import FTSLang, GQLInfo, LangCode, LangSep, PostgresFTSLangSpecificFields
+
+__all__ = [
+    "PostgresFTS",
+]
+
+
+class PostgresFTS:
+    """
+    Filter reference for Postgres full text search.
+
+    Creates a SearchVector for the request language, annotates it to the queryset,
+    and searches using a raw search string created using the `build_pg_search` function.
+    """
+
+    def __init__(
+        self,
+        *common: str,
+        separator: LangSep = "|",
+        **lang_specific: Unpack[PostgresFTSLangSpecificFields],
+    ) -> None:
+        """
+        Postgres full text search filter reference.
+
+        :param common: Common fields for all languages.
+        :param separator: Separator for each search term in the query.
+        :param lang_specific: Fields specific to each language.
+        """
+        self.separator = separator
+        self.vectors: dict[FTSLang, SearchVector] = {
+            lang: SearchVector(*set(*common, *fields), config=lang)  # type: ignore[misc]
+            for lang, fields in lang_specific.items()
+        }
+
+    def get_search_language(self, info: GQLInfo) -> SearchLanguage:
+        lang = get_request_search_language(info)
+        if lang not in self.vectors:
+            return TextSearchLang.ENGLISH
+        return lang
+
+    def get_vector_alias_key(self, ftr: Filter, lang: SearchLanguage) -> str:
+        return f"{undine_settings.PG_TEXT_SEARCH_PREFIX}_{ftr.name}_{lang.name}"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PostgresFTSExpressionResolver:
+    """Resolves a filter using a Postgres full text search."""
+
+    fts: PostgresFTS
+
+    def __call__(self, root: Filter, info: GQLInfo, *, value: str) -> Q:
+        lang = self.fts.get_search_language(info)
+        key = self.fts.get_vector_alias_key(root, lang)
+        search = build_pg_search(value, separator=self.fts.separator)
+        query = {key: SearchQuery(value=search, config=lang.name, search_type="raw")}
+        return Q(**query)
+
+
+class SearchLanguage(UserString):
+    """Postgres search language with the corresponding language code."""
+
+    def __init__(self, name: FTSLang, *, code: LangCode) -> None:
+        self.name = name
+        self.code = code
+        super().__init__(name)
+
+
+class TextSearchLang:
+    """Default postgres text search language configurations."""
+
+    ARABIC = SearchLanguage("arabic", code="ar")
+    ARMENIAN = SearchLanguage("armenian", code="hy")
+    BASQUE = SearchLanguage("basque", code="eu")
+    CATALAN = SearchLanguage("catalan", code="ca")
+    DANISH = SearchLanguage("danish", code="da")
+    DUTCH = SearchLanguage("dutch", code="nl")
+    ENGLISH = SearchLanguage("english", code="en")
+    FINNISH = SearchLanguage("finnish", code="fi")
+    FRENCH = SearchLanguage("french", code="fr")
+    GERMAN = SearchLanguage("german", code="de")
+    GREEK = SearchLanguage("greek", code="el")
+    HINDI = SearchLanguage("hindi", code="hi")
+    HUNGARIAN = SearchLanguage("hungarian", code="hu")
+    INDONESIAN = SearchLanguage("indonesian", code="id")
+    IRISH = SearchLanguage("irish", code="ga")
+    ITALIAN = SearchLanguage("italian", code="it")
+    LITHUANIAN = SearchLanguage("lithuanian", code="lt")
+    NEPALI = SearchLanguage("nepali", code="ne")
+    NORWEGIAN = SearchLanguage("norwegian", code="nb")
+    PORTUGUESE = SearchLanguage("portuguese", code="pt")
+    ROMANIAN = SearchLanguage("romanian", code="ro")
+    RUSSIAN = SearchLanguage("russian", code="ru")
+    SERBIAN = SearchLanguage("serbian", code="sr")
+    SPANISH = SearchLanguage("spanish", code="es")
+    SWEDISH = SearchLanguage("swedish", code="sv")
+    TAMIL = SearchLanguage("tamil", code="ta")
+    TURKISH = SearchLanguage("turkish", code="tr")
+    YIDDISH = SearchLanguage("yiddish", code="yi")
+
+    @classmethod
+    def members(cls) -> dict[str, SearchLanguage]:
+        return get_members(cls, SearchLanguage)
+
+    @classmethod
+    def for_code(cls, code: LangCode, *, default: SearchLanguage = ENGLISH) -> SearchLanguage:
+        members = cls.members()
+        for search_lang in members.values():
+            if search_lang.code == code:
+                return search_lang
+        return default
+
+
+def normalize_search_text(text: str) -> str:
+    """
+    Normalize the given text to use in full text search.
+
+    Replaces all non-word and non-space characters with spaces and removes multiple spaces.
+    Each string of chars separated by space then becomes a search term.
+    Each search term is then quoted and matched as a possible start of word.
+    """
+    text = unicodedata.normalize("NFKC", text)  # Normalize text to unicode form
+    text = re.sub(r"[^\w\s]", " ", text)  # Remove all non-word and non-space characters
+    return re.sub(r"\s+", " ", text)  # Collapse multiple spaces
+
+
+def build_pg_search(text: str, *, separator: LangSep = "|") -> str:
+    """
+    Build raw postgres full text search query from the given text.
+    Text is normalized first by removing punctuation, etc.
+
+    Each search term is matched together with other search terms using the given operator.
+      | = Only one of the search terms needs to match
+      & = All search terms need to match
+      <-> = Each search term must be followed by the others
+      <3> = Each search term must be followed by less than 3 "words" away (<1> same as <->)
+
+    Ref. https://www.postgresql.org/docs/current/datatype-textsearch.html#DATATYPE-TSQUERY
+    """
+    norm_text = normalize_search_text(text)
+    search_terms = (f"'{value}':*" for value in norm_text.split(" ") if value)
+    return f" {separator} ".join(search_terms)
+
+
+def get_request_search_language(info: GQLInfo) -> SearchLanguage:
+    """
+    Get language from the given request using this order:
+
+    1. Referer header path
+    2. Request info path
+    3. Cookie as set by the LANGUAGE_COOKIE_NAME setting
+    4. Accept-Language header
+    5. Default language as set by the LANGUAGE_CODE setting
+    """
+    referer = info.context.META.get("HTTP_REFERER")
+    if referer:
+        path = urllib.parse.urlparse(referer).path
+        lang: LangCode = get_language_from_path(path)  # type: ignore[assignment]
+        if lang is not None:
+            return TextSearchLang.for_code(lang)
+
+    lang = get_language_from_request(info.context, check_path=True)  # type: ignore[assignment,arg-type]
+    return TextSearchLang.for_code(lang)

--- a/undine/utils/model_utils.py
+++ b/undine/utils/model_utils.py
@@ -27,13 +27,12 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
 
     from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
-    from django.db.models import Field, ManyToManyRel, Model
+    from django.db.models import Field, Manager, ManyToManyRel, Model
 
     from undine.typing import (
         CombinableExpression,
         GenericField,
         ModelField,
-        ModelManager,
         RelatedField,
         TModel,
         ToManyField,
@@ -64,7 +63,7 @@ __all__ = [
 ]
 
 
-def get_default_manager(model: type[TModel]) -> ModelManager[TModel]:
+def get_default_manager(model: type[TModel]) -> Manager[TModel]:
     """Get the default manager for the given model."""
     return model._meta.default_manager  # type: ignore[return-value]
 


### PR DESCRIPTION
# Description

- `Filter` and `Order` aliases are now given from a function instead of as an input argument
- Convert `TypedDict` keys to schema case
- Do not override custom user `Field.optimizer_func` or `Filter.aliases_func` but extend them instead
- Also adds experimental `PostgresFTS` filtering
- Fixes some types

---
