### PR TITLE
Fix: Add 'search' lookup mapping to GraphQLString

### DIFF
--- a/undine/converters/impl/convert_lookup_to_graphql_type.py
+++ b/undine/converters/impl/convert_lookup_to_graphql_type.py
@@ -53,6 +53,7 @@ def _(
         "iregex",
         "istartswith",
         "regex",
+        "search",
     ],
     **kwargs: Any,
 ) -> GraphQLInputType | GraphQLOutputType:


### PR DESCRIPTION
n django.contrib.postgres is added to INSTALLED_APPS, Django registers PostgreSQL-specific lookups, including the full-text search lookup (__search). Because undine attempts to automatically convert model field lookups into GraphQL types, encountering the search lookup causes schema generation to crash with the following error:

FunctionDispatcherError: Could not find a matching GraphQL type for lookup: 'search'.
Fix: This PR adds the missing "search" lookup to the mapping registry in undine/converters/impl/convert_lookup_to_graphql_type.py, allowing it to resolve correctly to GraphQLString (which matches the expected input type for Django's search queries).

Testing:

Verified that adding django.contrib.postgres to INSTALLED_APPS no longer crashes the application on startup.
The search filter is now properly parsed and functional within the generated GraphQL schema.